### PR TITLE
atualiza URL do portal de MG

### DIFF
--- a/dados/catalogos.csv
+++ b/dados/catalogos.csv
@@ -6,7 +6,7 @@ Dados abertos Distrito Federal,http://dados.df.gov.br/,,DF,Estadual,Executivo,CK
 Dados abertos – Governo do ES,https://transparencia.es.gov.br/DadosAbertos/BaseDeDados#,,ES,Estadual,Executivo,Interna
 Dados abertos – Goiás Transparente,http://www.transparencia.go.gov.br/portaldatransparencia/institucional/dados-abertos,,GO,Estadual,Executivo,Interna
 Dados abertos – Assembleia de Minas,http://dadosabertos.almg.gov.br/ws/ajuda/sobre,,MG,Estadual,Legislativo,Interna
-Dados abertos – Estado de MG,http://www.transparencia.mg.gov.br/dados-abertos,,MG,Estadual,Executivo,CKAN
+Dados abertos – Estado de MG,http://www.dados.mg.gov.br,MG,Estadual,Executivo,CKAN
 Dados abertos do SAGRES – TCE/PB,http://portal.tce.pb.gov.br/dados-abertos-do-sagres-tcepb/,,PB,Estadual,Legislativo,Interna
 Dados abertos – Governo de Pernambuco,http://www.dadosabertos.pe.gov.br/,,PE,Estadual,Executivo,Interna
 Dados Recife,http://dados.recife.pe.gov.br,Recife,PE,Municipal,Executivo,CKAN


### PR DESCRIPTION
A partir de 18 de julho de 2020, a seção de [Dados Abertos do Portal da Transparência](http://www.transparencia.mg.gov.br/dados-abertos) foi sucedida pelo novo [Portal de Dados Abertos](http://www.dados.mg.gov.br/).